### PR TITLE
Set all addresses to Chicago

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: node server.js
+web-dev: nodemon server.js

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,30 @@
+var express = require('express');
+// var bodyParser = require('body-parser');
+
+var app = express();
+var CONFIG = require('config').BASE;
+
+var allowCrossDomain = function(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
+    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Content-Length, X-Requested-With');
+    
+    if(req.method == 'OPTIONS') {
+        res.sendStatus(200)
+    } else {
+        next();
+    }
+}
+
+app.port = CONFIG.PORT;
+
+// app.use(bodyParser.urlencoded({
+//     extended: false
+// })); 
+app.use(allowCrossDomain);
+
+var routes = require('./routes');
+
+routes(app);
+
+module.exports = app

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,0 +1,11 @@
+(function() {
+  var v1 = require('./v1');
+
+  module.exports = function(app) {
+
+    /* API: V1 */
+    app.route('/v1/address')
+      .get(v1.address);
+    };
+
+}).call(this);

--- a/app/routes/v1/index.js
+++ b/app/routes/v1/index.js
@@ -3,14 +3,29 @@ var CONFIG = require('config').BASE;
 
 var geocodio = new Geocodio(CONFIG.geocodio);
 
+var parser = require('parse-address');
+
 (function() {
     module.exports = {
        address: function ( req, res ) {
-		var address = req.query.a;
+		var address = parser.parseLocation(req.query.a);
+		address.city = 'Chicago';
+		address.state = 'IL';
 
-		geocodio.get('geocode', {q: address}, function(err, response){
+		var geocodioAddress = address.number;
+		if (address.prefix) geocodioAddress += ' ' + address.prefix;
+		if (address.street) geocodioAddress += ' ' + address.street;
+		if (address.type) geocodioAddress += ' ' + address.type;
+		if (address.city) geocodioAddress += ' ' + address.city;
+		if (address.state) geocodioAddress += ' ' + address.state;
+		if (address.zip) geocodioAddress += ' ' + address.zip;
+
+	  console.log(geocodioAddress);
+
+		geocodio.get('geocode', {q: geocodioAddress}, function(err, response){
 		    if (err) {
-		    	res.sendStatus(400);
+		    	console.log(err);
+		    	res.sendStatus(400, err);
 		    } else {
 			    var result = JSON.parse(response).results[0];
 			    console.log(result);

--- a/app/routes/v1/index.js
+++ b/app/routes/v1/index.js
@@ -1,0 +1,25 @@
+var Geocodio = require('geocodio');
+var CONFIG = require('config').BASE;
+
+var geocodio = new Geocodio(CONFIG.geocodio);
+
+(function() {
+    module.exports = {
+       address: function ( req, res ) {
+		var address = req.query.a;
+
+		geocodio.get('geocode', {q: address}, function(err, response){
+		    if (err) {
+		    	res.sendStatus(400);
+		    } else {
+			    var result = JSON.parse(response).results[0];
+		       	res.send({
+		       		lat:result.location.lat,
+		       		lng:result.location.lng,
+		       		formatted:result.formatted_address
+		       	});
+		    }
+		});
+       }
+    }
+}).call(this);

--- a/app/routes/v1/index.js
+++ b/app/routes/v1/index.js
@@ -13,6 +13,7 @@ var geocodio = new Geocodio(CONFIG.geocodio);
 		    	res.sendStatus(400);
 		    } else {
 			    var result = JSON.parse(response).results[0];
+			    console.log(result);
 		       	res.send({
 		       		lat:result.location.lat,
 		       		lng:result.location.lng,

--- a/app/routes/v1/index.js
+++ b/app/routes/v1/index.js
@@ -8,34 +8,40 @@ var parser = require('parse-address');
 (function() {
     module.exports = {
        address: function ( req, res ) {
-		var address = parser.parseLocation(req.query.a);
-		address.city = 'Chicago';
-		address.state = 'IL';
+			var address = parser.parseLocation(req.query.a);
 
-		var geocodioAddress = address.number;
-		if (address.prefix) geocodioAddress += ' ' + address.prefix;
-		if (address.street) geocodioAddress += ' ' + address.street;
-		if (address.type) geocodioAddress += ' ' + address.type;
-		if (address.city) geocodioAddress += ' ' + address.city;
-		if (address.state) geocodioAddress += ' ' + address.state;
-		if (address.zip) geocodioAddress += ' ' + address.zip;
+			if (address.number) {
+				var geocodioAddress = address.number;
+				address.city = 'Chicago';
+				address.state = 'IL';
+				if (address.prefix) geocodioAddress += ' ' + address.prefix;
+				if (address.street) geocodioAddress += ' ' + address.street;
+				if (address.type) geocodioAddress += ' ' + address.type;
+				if (address.city) geocodioAddress += ' ' + 'Chicago';
+				if (address.state) geocodioAddress += ' ' + 'IL';
+				if (address.zip) geocodioAddress += ' ' + address.zip;
+				
+				geocodio.get('geocode', {q: geocodioAddress}, function(err, response){
+				    if (err) {
+				    	res.sendStatus(400, err);
+				    } else {
+					    var result = JSON.parse(response).results[0];
 
-	  console.log(geocodioAddress);
+				       	res.send({
+				       		lat:result.location.lat,
+				       		lng:result.location.lng,
+				       		formatted:result.formatted_address
+				       	});
+				    }
+				});
 
-		geocodio.get('geocode', {q: geocodioAddress}, function(err, response){
-		    if (err) {
-		    	console.log(err);
-		    	res.sendStatus(400, err);
-		    } else {
-			    var result = JSON.parse(response).results[0];
-			    console.log(result);
-		       	res.send({
-		       		lat:result.location.lat,
-		       		lng:result.location.lng,
-		       		formatted:result.formatted_address
-		       	});
-		    }
-		});
+			} else {
+				res.sendStatus(400, 'need street address');
+			}
+
+
+
+
        }
     }
 }).call(this);

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,13 @@
+config = {};
+
+config.BASE = {};
+
+config.BASE.ENV = "development";
+config.BASE.PORT = 8080;
+config.BASE.CPU_COUNT = 1;
+
+config.BASE.geocodio = {
+	api_key: process.env.GEOCODIO_KEY
+}
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "no2bluelivesordinance",
+  "version": "1.0.0",
+  "description": "App to Contact Chicago City Council Alderman Via Email or Phone against Blue Lives Ordinance",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start-dev":"nodemon server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/byp100/No2BlueLivesOrdinance.git"
+  },
+  "author": "Rich Ranallo",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/byp100/No2BlueLivesOrdinance/issues"
+  },
+  "dependencies": {
+    "cluster": "^0.7.7",
+    "config": "1.x",
+    "express": "4.x",
+    "geocodio": "^2.0.0"
+  },
+  "devDependencies": {},
+  "homepage": "https://github.com/byp100/No2BlueLivesOrdinance#readme"
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start-dev":"nodemon server.js"
+    "start-dev": "nodemon server.js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,8 @@
     "cluster": "^0.7.7",
     "config": "1.x",
     "express": "4.x",
-    "geocodio": "^2.0.0"
+    "geocodio": "^2.0.0",
+    "parse-address": "0.0.5"
   },
   "devDependencies": {},
   "homepage": "https://github.com/byp100/No2BlueLivesOrdinance#readme"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+var app, port, cluster, CONFIG, bodyParser;
+
+cluster = require('cluster');
+
+CONFIG = require('config').BASE;
+
+// Code to run if we're in the master process
+if (cluster.isMaster) {
+  // Count the machine's CPUs
+  var cpuCount = CONFIG.CPU_COUNT;
+
+  // Create a worker for each CPU
+  for (var i = 0; i < cpuCount; i += 1) {
+    cluster.fork();
+  }
+
+  // Listen for dying workers
+  cluster.on('exit', function (worker) {
+    // Replace the dead worker
+    cluster.fork();
+  });
+} else {
+  app = require('./app');
+
+  port = process.env.PORT || app.port;
+
+  app.listen(port, function() {
+    return console.log("Listening on " + port + "\nPress CTRL-C to stop server.");
+  });
+}


### PR DESCRIPTION
I solved our Plano, TX problem. I'm now parsing all addresses into their component sections first, then setting city/state to Chicago, IL, then sending it in for reverse geocoding. This way, it'll work and assume a Chicago address whether or not someone puts that in the search term.

I'm still deploying from my fork, though; Heroku has permissions and can find the repo, but it can't deploy unless I have admin privs to it. So maybe we'll just do this tomorrow at some point and I'll hover over someone's shoulder who has the permissions to do that.

It doesn't affect actual performance, but changing this is something we should do at some point just so all the code is under BYP's umbrella.